### PR TITLE
fix: remove challenge join in user profile query

### DIFF
--- a/src/services/supabase.js
+++ b/src/services/supabase.js
@@ -199,10 +199,7 @@ export const supabaseHelpers = {
           sessions_count:cooking_sessions(count),
           followers_count:followers!followed_id(count),
           following_count:followers!follower_id(count),
-          challenges_completed:challenge_participants!inner(
-            count,
-            challenges!inner(*)
-          )
+          challenges_completed:challenge_participants!inner(count)
         `)
         .eq('id', userId)
         .single()


### PR DESCRIPTION
## Summary
- prevent login error by removing unnecessary challenge join from user profile query

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6894d094c56083308981445e989c36f5