### PR TITLE
fix: specify FK for challenge count

### DIFF
--- a/src/services/supabase.js
+++ b/src/services/supabase.js
@@ -199,7 +199,8 @@ export const supabaseHelpers = {
           sessions_count:cooking_sessions(count),
           followers_count:followers!followed_id(count),
           following_count:followers!follower_id(count),
-          challenges_completed:challenge_participants!inner(count)
+          -- Use explicit FK reference to avoid ambiguous join
+          challenges_completed:challenge_participants!user_id(count)
         `)
         .eq('id', userId)
         .single()


### PR DESCRIPTION
## Summary
- avoid ambiguous joins when counting completed challenges by using explicit `user_id` FK

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6894d269cb008330b82d64285178c229