### PR TITLE
fix: create profile after auth

### DIFF
--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -19,31 +19,6 @@ export const authService = {
       
       if (authError) throw authError
 
-      // 2. Si l'utilisateur est créé, créer son profil dans la table users
-      if (authData.user) {
-        const { error: profileError } = await supabase
-          .from('users')
-          .insert([{
-            id: authData.user.id,
-            email: email,
-            username: metadata.username || email.split('@')[0],
-            bio: metadata.bio || '',
-            avatar_url: null,
-            cook_frequency: null,
-            cook_constraints: [],
-            xp: 0,
-            is_private: false,
-            onboarding_completed: false,
-            created_at: new Date().toISOString(),
-            last_seen: new Date().toISOString()
-          }])
-
-        if (profileError) {
-          console.warn('Erreur création profil:', profileError)
-          // On continue même si le profil n'est pas créé
-        }
-      }
-
       return {
         user: authData.user,
         session: authData.session,

--- a/src/stores/authStore.js
+++ b/src/stores/authStore.js
@@ -30,9 +30,10 @@ export const useAuthStore = create(
           const session = await authService.getSession()
           
           if (session?.user) {
-            // Récupérer le profil utilisateur complet depuis la table users
+            // Créer le profil s'il n'existe pas puis le récupérer
+            await supabaseHelpers.ensureUserProfile(session.user)
             const profile = await supabaseHelpers.getUserProfile(session.user.id)
-            
+
             set({
               session,
               user: profile ? { ...session.user, ...profile } : session.user,
@@ -88,18 +89,19 @@ export const useAuthStore = create(
           set({ loading: true, error: null })
           
           const { user, session } = await authService.signIn(email, password)
-          
+
           if (user && session) {
-            // Récupérer le profil complet
+            // S'assurer que le profil existe puis le récupérer
+            await supabaseHelpers.ensureUserProfile(user)
             const profile = await supabaseHelpers.getUserProfile(user.id)
-            
+
             set({
               session,
               user: profile ? { ...user, ...profile } : user,
               loading: false,
               error: null
             })
-            
+
             return { success: true }
           }
         } catch (error) {


### PR DESCRIPTION
## Summary
- create `ensureUserProfile` helper to auto-insert profile records
- create profiles on initial session restore or sign in
- simplify sign-up to rely on post-auth profile creation

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_6894d269cb008330b82d64285178c229