### PR TITLE
Graceful handling for sessions without user data

### DIFF
--- a/src/components/cards/SessionCard.js
+++ b/src/components/cards/SessionCard.js
@@ -142,19 +142,19 @@ const SessionCard = ({
       <View style={styles.content}>
         {/* Header avec utilisateur */}
         <View style={styles.header}>
-          <TouchableOpacity 
+          <TouchableOpacity
             style={styles.userInfo}
             onPress={() => onUserPress?.(session)}
           >
-            <Avatar 
-              source={{ uri: session.user.avatar_url }}
+            <Avatar
+              source={session.user?.avatar_url ? { uri: session.user.avatar_url } : undefined}
               size="small"
-              name={session.user.username}
-              xp={session.user.xp}
+              name={session.user?.username || 'Utilisateur inconnu'}
+              xp={session.user?.xp || 0}
               showBadge={true}
             />
             <View style={styles.userDetails}>
-              <Text style={styles.username}>{session.user.username}</Text>
+              <Text style={styles.username}>{session.user?.username || 'Utilisateur inconnu'}</Text>
               <Text style={styles.timeAgo}>{session.timeAgo}</Text>
             </View>
           </TouchableOpacity>


### PR DESCRIPTION
## Summary
- prevent crashes when `session.user` is missing by using optional chaining and fallback avatar/text

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx -p react-test-renderer -p @babel/register node -r @babel/register -` *(fails: Cannot find module '@babel/register')*

------
https://chatgpt.com/codex/tasks/task_e_6897c38719a48330b9ecf20c32433e22