### PR TITLE
fix: ensure session cards display live XP levels

### DIFF
--- a/src/screens/profile/UserProfileScreen.js
+++ b/src/screens/profile/UserProfileScreen.js
@@ -19,7 +19,7 @@ import { useSessionStore } from '../../stores/sessionStore';
 import { Header } from '../../components/layout/Header';
 import { SessionCard } from '../../components/cards/SessionCard';
 import { Avatar, Button } from '../../components/common';
-import { COLORS, SPACING, TYPOGRAPHY, RADIUS, SHADOWS } from '../../utils/constants';
+import { COLORS, SPACING, TYPOGRAPHY, RADIUS, SHADOWS, getLevelFromXP } from '../../utils/constants';
 
 export const UserProfileScreen = ({ route, navigation }) => {
   const { userId } = route.params;
@@ -128,6 +128,7 @@ export const UserProfileScreen = ({ route, navigation }) => {
 
   // Get user info from first session if available
   const displayUser = userSessions.length > 0 ? userSessions[0].user : null;
+  const displayLevel = displayUser ? getLevelFromXP(displayUser.xp || 0) : null;
 
   if (userLoading) {
     return (
@@ -166,13 +167,14 @@ export const UserProfileScreen = ({ route, navigation }) => {
                 source={{ uri: displayUser?.avatar_url }}
                 size="large"
                 name={displayUser?.username || 'Utilisateur'}
+                xp={displayUser?.xp || 0}
               />
               <View style={styles.userInfo}>
                 <Text style={styles.username}>
                   {displayUser?.username || 'Nom d\'utilisateur'}
                 </Text>
                 <Text style={styles.cookingLevel}>
-                  Niveau: {displayUser?.cooking_level || 'Non d�fini'}
+                  Niveau: {displayLevel?.name || 'Non défini'}
                 </Text>
               </View>
             </View>

--- a/src/services/clubs.js
+++ b/src/services/clubs.js
@@ -244,7 +244,7 @@ export const clubsService = {
         .from('cooking_sessions')
         .select(`
           *,
-          user:users(username, avatar_url, cooking_level)
+          user:users(username, avatar_url, xp, cooking_level)
         `)
         .in('id', sessionIds)
 
@@ -314,7 +314,8 @@ export const clubsService = {
           user: {
             username: session.user?.username,
             avatar_url: session.user?.avatar_url,
-            cooking_level: session.user?.cooking_level
+            cooking_level: session.user?.cooking_level,
+            xp: session.user?.xp
           },
           likesCount: likeCountMap[session.id] || 0,
           commentsCount: commentCountMap[session.id] || 0,

--- a/src/services/session.js
+++ b/src/services/session.js
@@ -11,7 +11,7 @@ export const sessionsService = {
         .from('cooking_sessions')
         .select(`
           *,
-          user:users(username, avatar_url, cooking_level)
+          user:users(username, avatar_url, xp, cooking_level)
         `)
         .order('created_at', { ascending: false })
         .range(page * limit, (page + 1) * limit - 1)
@@ -90,7 +90,8 @@ export const sessionsService = {
         user: {
           username: session.user?.username,
           avatar_url: session.user?.avatar_url,
-          cooking_level: session.user?.cooking_level
+          cooking_level: session.user?.cooking_level,
+          xp: session.user?.xp
         },
         likesCount: likeCountMap[session.id] || 0,
         commentsCount: commentCountMap[session.id] || 0,
@@ -132,7 +133,7 @@ export const sessionsService = {
         .from('cooking_sessions')
         .select(`
           *,
-          user:users(username, avatar_url, cooking_level)
+          user:users(username, avatar_url, xp, cooking_level)
         `)
         .eq('id', sessionId)
         .single()
@@ -197,7 +198,8 @@ export const sessionsService = {
         user: {
           username: session.user?.username,
           avatar_url: session.user?.avatar_url,
-          cooking_level: session.user?.cooking_level
+          cooking_level: session.user?.cooking_level,
+          xp: session.user?.xp
         },
         likesCount: likesCount || 0,
         commentsCount: comments?.length || 0,

--- a/src/stores/sessionStore.js
+++ b/src/stores/sessionStore.js
@@ -269,3 +269,26 @@ export const useSessionStore = create((set, get) => ({
   }
 }))
 
+// Met à jour l'XP des sessions du user courant lorsque son XP change
+useAuthStore.subscribe(
+  (state) => state.user?.xp,
+  (xp) => {
+    const userId = useAuthStore.getState().user?.id
+    if (!userId) return
+
+    const { sessions, currentSession } = useSessionStore.getState()
+
+    const updatedSessions = sessions.map(session =>
+      session.user_id === userId
+        ? { ...session, user: { ...session.user, xp } }
+        : session
+    )
+
+    const updatedCurrent = currentSession && currentSession.user_id === userId
+      ? { ...currentSession, user: { ...currentSession.user, xp } }
+      : currentSession
+
+    useSessionStore.setState({ sessions: updatedSessions, currentSession: updatedCurrent })
+  }
+)
+


### PR DESCRIPTION
## Summary
- include user XP in session and club feed queries
- update session store when the current user's XP changes
- render profile and session cards with dynamic level info

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Missing script "lint")*


------
https://chatgpt.com/codex/tasks/task_e_6897c808d37c8330a912809f5d8e4666