### PR TITLE
feat: enable avatar navigation to user profiles

### DIFF
--- a/src/components/Common/Avatar.js
+++ b/src/components/Common/Avatar.js
@@ -1,12 +1,13 @@
 // src/components/common/Avatar.js
 import React from 'react'
-import { 
-  View, 
-  Image, 
-  Text, 
-  StyleSheet, 
-  TouchableOpacity 
+import {
+  View,
+  Image,
+  Text,
+  StyleSheet,
+  TouchableOpacity
 } from 'react-native'
+import { useNavigation } from '@react-navigation/native'
 import { LinearGradient } from 'expo-linear-gradient'
 import { COLORS, SPACING, TYPOGRAPHY, RADIUS } from '../../utils/constants'
 import { getLevelFromXP } from '../../utils/constants'
@@ -18,9 +19,11 @@ const Avatar = ({
   xp = 0,
   showBadge = false,
   onPress,
+  userId,
   style,
   ...props
 }) => {
+  const navigation = useNavigation()
   const sizeValue = sizes[size]
   const level = getLevelFromXP(xp)
   
@@ -57,9 +60,17 @@ const Avatar = ({
     </View>
   )
 
-  if (onPress) {
+  const handlePress = () => {
+    if (onPress) {
+      onPress()
+    } else if (userId) {
+      navigation.navigate('UserProfileScreen', { userId })
+    }
+  }
+
+  if (onPress || userId) {
     return (
-      <TouchableOpacity onPress={onPress}>
+      <TouchableOpacity onPress={handlePress}>
         <AvatarContent />
       </TouchableOpacity>
     )

--- a/src/components/cards/ClubCard.js
+++ b/src/components/cards/ClubCard.js
@@ -205,6 +205,7 @@ const ClubCard = ({
                 source={{ uri: member.avatar_url }}
                 name={member.username}
                 size="small"
+                userId={member.id}
                 style={[
                   styles.memberAvatar,
                   index > 0 && { marginLeft: -8 }

--- a/src/components/cards/SessionCard.js
+++ b/src/components/cards/SessionCard.js
@@ -1,14 +1,15 @@
 // src/components/cards/SessionCard.js
 import React, { useState, useRef, useEffect } from 'react'
-import { 
-  View, 
-  Text, 
-  Image, 
-  TouchableOpacity, 
-  StyleSheet, 
+import {
+  View,
+  Text,
+  Image,
+  TouchableOpacity,
+  StyleSheet,
   Dimensions,
-  Animated 
+  Animated
 } from 'react-native'
+import { useNavigation } from '@react-navigation/native'
 import { LinearGradient } from 'expo-linear-gradient'
 import { Avatar, Badge } from '../common'
 import { COLORS, SPACING, TYPOGRAPHY, RADIUS, SHADOWS } from '../../utils/constants'
@@ -31,6 +32,7 @@ const SessionCard = ({
   const [saved, setSaved] = useState(session.isSaved || false)
   const [likesCount, setLikesCount] = useState(session.likesCount || 0)
   const [commentsCount, setCommentsCount] = useState(session.commentsCount || 0)
+  const navigation = useNavigation()
   
   const likeAnimation = useRef(new Animated.Value(1)).current
 
@@ -144,7 +146,13 @@ const SessionCard = ({
         <View style={styles.header}>
           <TouchableOpacity
             style={styles.userInfo}
-            onPress={() => onUserPress?.(session)}
+            onPress={() => {
+              if (onUserPress) {
+                onUserPress(session)
+              } else {
+                navigation.navigate('UserProfileScreen', { userId: session.user_id })
+              }
+            }}
           >
             <Avatar
               source={session.user?.avatar_url ? { uri: session.user.avatar_url } : undefined}
@@ -152,6 +160,7 @@ const SessionCard = ({
               name={session.user?.username || 'Utilisateur inconnu'}
               xp={session.user?.xp || 0}
               showBadge={true}
+              userId={session.user_id}
             />
             <View style={styles.userDetails}>
               <Text style={styles.username}>{session.user?.username || 'Utilisateur inconnu'}</Text>

--- a/src/components/cards/UserCard.js
+++ b/src/components/cards/UserCard.js
@@ -6,6 +6,7 @@ import {
   TouchableOpacity,
   StyleSheet
 } from 'react-native'
+import { useNavigation } from '@react-navigation/native'
 import { Avatar, Badge, Button } from '../common'
 import { COLORS, SPACING, TYPOGRAPHY, RADIUS, SHADOWS, getLevelFromXP } from '../../utils/constants'
 
@@ -21,6 +22,7 @@ const UserCard = ({
   style,
   ...props
 }) => {
+  const navigation = useNavigation()
   if (!user) return null
 
   const isFollowing = user?.isFollowing
@@ -37,9 +39,12 @@ const UserCard = ({
   // Version compacte (pour les listes)
   if (variant === 'compact') {
     return (
-      <TouchableOpacity 
-        style={[styles.userCardCompact, style]} 
-        onPress={() => onPress?.(user)}
+      <TouchableOpacity
+        style={[styles.userCardCompact, style]}
+        onPress={() => {
+          if (onPress) onPress(user)
+          else navigation.navigate('UserProfileScreen', { userId: user.id })
+        }}
         {...props}
       >
         <Avatar
@@ -48,6 +53,7 @@ const UserCard = ({
           size="medium"
           xp={user?.xp}
           showBadge={true}
+          userId={user.id}
         />
         
         <View style={styles.userInfoCompact}>
@@ -78,9 +84,12 @@ const UserCard = ({
 
   // Version détaillée (pour les suggestions, recherche)
   return (
-    <TouchableOpacity 
-      style={[styles.userCard, style]} 
-      onPress={() => onPress?.(user)}
+    <TouchableOpacity
+      style={[styles.userCard, style]}
+      onPress={() => {
+        if (onPress) onPress(user)
+        else navigation.navigate('UserProfileScreen', { userId: user.id })
+      }}
       activeOpacity={0.9}
       {...props}
     >
@@ -92,6 +101,7 @@ const UserCard = ({
           size="large"
           xp={user?.xp}
           showBadge={true}
+          userId={user.id}
         />
         
         <View style={styles.userMainInfo}>

--- a/src/screens/challenges/ChallengeDetailScreen.js
+++ b/src/screens/challenges/ChallengeDetailScreen.js
@@ -221,7 +221,14 @@ const ChallengeDetailScreen = ({ navigation }) => {
           <Section title="👥 Participants" subtitle={`${participantsCount || 0} participant(s)`}>
             <View style={styles.participantsList}>
               {(participants_list || []).slice(0, 5).map(p => (
-                <Avatar key={p.user.id} source={{ uri: p.user.avatar_url }} name={p.user.username} size="medium" style={styles.participantAvatar} />
+                <Avatar
+                  key={p.user.id}
+                  source={{ uri: p.user.avatar_url }}
+                  name={p.user.username}
+                  size="medium"
+                  style={styles.participantAvatar}
+                  userId={p.user.id}
+                />
               ))}
               {(participants_list?.length || 0) > 5 && <Text style={styles.moreParticipants}>+{(participants_list.length || 0) - 5}</Text>}
             </View>

--- a/src/screens/clubs/ClubMembersScreen.js
+++ b/src/screens/clubs/ClubMembersScreen.js
@@ -102,6 +102,7 @@ export const ClubMembersScreen = ({ navigation }) => {
               name={user.username || 'Utilisateur inconnu'}
               size="medium"
               style={styles.memberAvatar}
+              userId={user.id || member.user_id}
             />
           <View style={styles.memberDetails}>
             <View style={styles.memberHeader}>

--- a/src/screens/clubs/JoinRequestsScreen.js
+++ b/src/screens/clubs/JoinRequestsScreen.js
@@ -93,6 +93,7 @@ export const JoinRequestsScreen = ({ navigation }) => {
             name={username}
             xp={xp}
             showBadge={true}
+            userId={item.user_id || item.user?.id}
           />
           <View style={styles.userDetails}>
             <Text style={styles.username}>{username}</Text>

--- a/src/screens/home/SessionDetailScreen.js
+++ b/src/screens/home/SessionDetailScreen.js
@@ -201,6 +201,7 @@ export const SessionDetailScreen = ({ route, navigation }) => {
                 name={currentSession.user?.username}
                 xp={currentSession.user?.xp}
                 showBadge={true}
+                userId={currentSession.user_id || currentSession.user?.id}
               />
               <View style={styles.userInfo}>
                 <Text style={styles.username}>{currentSession.user?.username}</Text>
@@ -299,6 +300,7 @@ export const SessionDetailScreen = ({ route, navigation }) => {
                   source={{ uri: user?.avatar_url }}
                   size="small"
                   name={user?.username}
+                  userId={user?.id}
                 />
                 <View style={styles.commentInputContainer}>
                   <TextInput
@@ -333,6 +335,7 @@ export const SessionDetailScreen = ({ route, navigation }) => {
                         source={{ uri: comment.user?.avatar_url }}
                         size="small"
                         name={comment.user?.username}
+                        userId={comment.user_id}
                       />
                       <View style={styles.commentContent}>
                         <View style={styles.commentBubble}>

--- a/src/screens/profile/ProfileScreen.js
+++ b/src/screens/profile/ProfileScreen.js
@@ -108,7 +108,7 @@ export const ProfileScreen = ({ navigation }) => {
     return (
       <View style={styles.profileHeader}>
         <View style={styles.profileInfo}>
-          <Avatar source={{ uri: user.avatar_url }} size="large" name={user.username} />
+          <Avatar source={{ uri: user.avatar_url }} size="large" name={user.username} userId={user.id} />
           <View style={styles.userInfo}>
             <Text style={styles.username}>{user.username}</Text>
             <Text style={styles.bio} numberOfLines={2}>{user.bio || 'Aucune bio'}</Text>

--- a/src/screens/profile/UserProfileScreen.js
+++ b/src/screens/profile/UserProfileScreen.js
@@ -168,6 +168,7 @@ export const UserProfileScreen = ({ route, navigation }) => {
                 size="large"
                 name={displayUser?.username || 'Utilisateur'}
                 xp={displayUser?.xp || 0}
+                userId={displayUser?.id || userId}
               />
               <View style={styles.userInfo}>
                 <Text style={styles.username}>


### PR DESCRIPTION
## Summary
- add `userId` support to Avatar and navigate to a user's profile when tapped
- default SessionCard and UserCard interactions to open profile pages
- wire up avatars across session details, clubs and challenges to pass `userId`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6897ceec7d3c8330840159fae919e04a